### PR TITLE
Add GenomicFeatures::features to namespace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Depends: Biobase, methods, R (>= 2.13), scales, reshape2, ggplot2, matrixStats,
          FDb.InfiniumMethylation.hg19 (>= 2.2.0), minfi
 Imports: BiocGenerics, S4Vectors, IRanges, GenomeInfoDb, GenomicRanges,
          SummarizedExperiment, Biobase, graphics, lattice, annotate,
-         genefilter, AnnotationDbi, minfi, stats4, illuminaio
+         genefilter, AnnotationDbi, minfi, stats4, illuminaio,
+	 GenomicFeatures
 Suggests: lumi, lattice, limma, xtable, SQN, MASS, matrixStats,
           parallel, rtracklayer, Biostrings, methyAnalysis,
           TCGAMethylation450k, IlluminaHumanMethylation450kanno.ilmn12.hg19,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -19,6 +19,9 @@ importFrom(lattice,
            dotplot,
            parallel)
 
+importFrom(GenomicFeatures,
+           features)
+
 importFrom(minfi,
            mapToGenome)
 


### PR DESCRIPTION
This causes a bug with a package I develop that uses methylumi, as another function named features exists