### PR TITLE
Add golden-value test suite (closes #27)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Imports: BiocGenerics, S4Vectors, IRanges, GenomeInfoDb, GenomicRanges,
 Suggests: lumi, lattice, limma, xtable, SQN, MASS, matrixStats,
           parallel, rtracklayer, Biostrings, 
           TCGAMethylation450k, IlluminaHumanMethylation450kanno.ilmn12.hg19,
-          FDb.InfiniumMethylation.hg18 (>= 2.2.0), Homo.sapiens, knitr
+          FDb.InfiniumMethylation.hg18 (>= 2.2.0), Homo.sapiens, knitr,
+          testthat (>= 3.0.0)
 biocViews: DNAMethylation, TwoChannel, Preprocessing, QualityControl, CpGIsland
 Maintainer: Sean Davis <seandavi@gmail.com>
 Description: This package provides classes for holding and manipulating
@@ -51,3 +52,4 @@ BugReports: https://github.com/seandavi/methylumi/issues/new
 License: GPL-2
 Encoding: UTF-8
 RoxygenNote: 7.1.2
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(methylumi)
+
+test_check("methylumi")

--- a/tests/testthat/helper-methylumi.R
+++ b/tests/testthat/helper-methylumi.R
@@ -1,0 +1,41 @@
+## Golden values in these tests were captured from methylumi 2.59.1 -- the first
+## version that installs on Bioconductor 3.24 -- and verified identical to the
+## behaviour of the last release that installed anywhere. They exist to make
+## behavioural drift visible during the modernization work in #30 and #34.
+##
+## Comparisons use relative tolerance rather than identity so that a BLAS or
+## platform change does not turn the suite red for the wrong reason.
+
+TOL <- 1e-6
+
+## methylumIDAT() on the three bundled 27k IDATs takes several seconds, so
+## import once and reuse across test files.
+.cache <- new.env(parent = emptyenv())
+
+idat_path <- function() system.file("extdata", package = "methylumi")
+
+idat_barcodes <- function() {
+  unique(sub("_(Grn|Red)\\.idat$", "",
+             basename(list.files(idat_path(), pattern = "\\.idat$"))))
+}
+
+## Cached methylumIDAT() import of the bundled 27k IDATs.
+example_idats <- function() {
+  if (is.null(.cache$idats)) {
+    .cache$idats <- suppressMessages(
+      methylumIDAT(idat_barcodes(), idatPath = idat_path())
+    )
+  }
+  .cache$idats
+}
+
+## Cached methylumiR() import of the bundled GoldenGate text files.
+example_text <- function() {
+  if (is.null(.cache$text)) {
+    .cache$text <- suppressMessages(methylumiR(
+      system.file("extdata", "exampledata.samples.txt", package = "methylumi"),
+      qcfile = system.file("extdata", "exampledata.controls.txt", package = "methylumi")
+    ))
+  }
+  .cache$text
+}

--- a/tests/testthat/test-methylumIDAT.R
+++ b/tests/testthat/test-methylumIDAT.R
@@ -1,0 +1,76 @@
+## Raw IDAT import: methylumIDAT() on the three bundled HumanMethylation27
+## IDAT pairs, plus background correction and the minfi coercion.
+
+test_that("barcodes are discovered from the bundled IDATs", {
+  expect_equal(idat_barcodes(),
+               c("5318317007_A", "5318317007_B", "5318317007_C"))
+})
+
+test_that("methylumIDAT imports the bundled 27k IDATs", {
+  mi <- example_idats()
+  expect_s4_class(mi, "MethyLumiSet")
+  expect_equal(unname(dim(mi)), c(27578L, 3L))
+  expect_equal(annotation(mi), "IlluminaHumanMethylation27k")
+  expect_equal(sampleNames(mi), idat_barcodes())
+  expect_equal(head(featureNames(mi), 2), c("cg00000292", "cg00002426"))
+})
+
+test_that("methylumIDAT assay values are unchanged", {
+  mi <- example_idats()
+  expect_equal(sum(betas(mi), na.rm = TRUE),        25691.821526, tolerance = TOL)
+  expect_equal(sum(methylated(mi)),                    458162070, tolerance = TOL)
+  expect_equal(sum(unmethylated(mi)),                 1171217850, tolerance = TOL)
+  expect_equal(sum(pvals(mi)),                              0.25, tolerance = TOL)
+
+  ## Exactly one probe has an undefined beta (zero total intensity).
+  expect_equal(sum(is.na(betas(mi))), 1L)
+})
+
+test_that("methylumIDAT attaches QC and out-of-band data", {
+  mi <- example_idats()
+  expect_equal(unname(dim(QCdata(mi))), c(144L, 3L))
+  expect_equal(sum(unlist(intensities.OOB(mi)), na.rm = TRUE),
+               167458050, tolerance = TOL)
+})
+
+test_that("the parallel path gives the same answer as the serial path", {
+  ## This is the guard for replacing the .mclapply shim in #30: whatever the
+  ## parallel backend becomes, it must not change the numbers.
+  mi <- example_idats()
+  par <- suppressMessages(
+    methylumIDAT(idat_barcodes(), idatPath = idat_path(), parallel = TRUE)
+  )
+  expect_equal(betas(par),        betas(mi))
+  expect_equal(methylated(par),   methylated(mi))
+  expect_equal(unmethylated(par), unmethylated(mi))
+})
+
+test_that("noob background correction is unchanged", {
+  bg <- suppressMessages(methylumi.bgcorr(example_idats()))
+  expect_s4_class(bg, "MethyLumiSet")
+  expect_equal(sum(betas(bg), na.rm = TRUE), 25441.561351, tolerance = TOL)
+  expect_equal(sum(is.na(betas(bg))), 3L)
+})
+
+test_that("stripOOB drops the out-of-band assays without touching betas", {
+  mi <- example_idats()
+  so <- stripOOB(mi)
+  expect_equal(sort(assayDataElementNames(so)),
+               c("betas", "methylated", "pvals", "unmethylated"))
+  expect_equal(betas(so), betas(mi))
+})
+
+test_that("MethyLumiSet coerces to a minfi MethylSet", {
+  ms <- as(example_idats(), "MethylSet")
+  expect_s4_class(ms, "MethylSet")
+  expect_equal(unname(dim(ms)), c(27578L, 3L))
+  expect_equal(sum(minfi::getBeta(ms), na.rm = TRUE), 25692.398717, tolerance = TOL)
+})
+
+test_that("IDATsToMatrices reads both channels", {
+  mats <- suppressMessages(
+    IDATsToMatrices(idat_barcodes(), idatPath = idat_path())
+  )
+  expect_length(mats, 3L)
+  expect_named(mats, idat_barcodes())
+})

--- a/tests/testthat/test-methylumiR.R
+++ b/tests/testthat/test-methylumiR.R
@@ -1,0 +1,66 @@
+## Text import: methylumiR() on the bundled GoldenGate sample and control files.
+
+test_that("methylumiR imports the bundled sample file", {
+  mr <- example_text()
+  expect_s4_class(mr, "MethyLumiSet")
+  expect_equal(unname(dim(mr)), c(1536L, 10L))
+  expect_equal(head(sampleNames(mr), 3),
+               c("1632405013_R006_C012", "1632405013_R007_C001",
+                 "1632405013_R007_C002"))
+})
+
+test_that("methylumiR assay values are unchanged", {
+  mr <- example_text()
+  expect_equal(sum(betas(mr)),        5691.890947, tolerance = TOL)
+  expect_equal(sum(pvals(mr)),         473.826186, tolerance = TOL)
+  expect_equal(sum(methylated(mr)),   74208765.64, tolerance = TOL)
+  expect_equal(sum(unmethylated(mr)), 95192882.17, tolerance = TOL)
+  expect_false(anyNA(betas(mr)))
+})
+
+test_that("methylumiR reproduces the shipped mldat values", {
+  ## mldat is the saved result of importing these same files, so the numbers
+  ## must agree. Only the sample names differ: mldat carries the friendly
+  ## M_1..M_10 labels, the fresh import carries the sentrix barcodes.
+  data(mldat, package = "methylumi", envir = environment())
+  mr <- example_text()
+  expect_equal(unname(betas(mr)), unname(betas(mldat)), tolerance = TOL)
+  expect_equal(unname(pvals(mr)), unname(pvals(mldat)), tolerance = TOL)
+  expect_false(identical(sampleNames(mr), sampleNames(mldat)))
+})
+
+test_that("methylumiR attaches QC data from the controls file", {
+  qc <- QCdata(example_text())
+  expect_s4_class(qc, "MethyLumiQC")
+  expect_equal(unname(ncol(qc)), 10L)
+})
+
+test_that("methylumiR works without a controls file", {
+  mr <- suppressMessages(methylumiR(
+    system.file("extdata", "exampledata.samples.txt", package = "methylumi")
+  ))
+  expect_s4_class(mr, "MethyLumiSet")
+  expect_equal(unname(dim(mr)), c(1536L, 10L))
+  expect_equal(sum(betas(mr)), 5691.890947, tolerance = TOL)
+})
+
+test_that("extractBarcodeAndPosition parses sentrix identifiers", {
+  got <- extractBarcodeAndPosition("1632405013_R006_C012")
+  expect_s3_class(got, "data.frame")
+  expect_equal(names(got),
+               c("sentrix", "row", "column", "rowNumber", "columnNumber"))
+  expect_equal(as.character(got$sentrix), "1632405013")
+  expect_equal(as.character(got$row), "R006")
+  expect_equal(as.character(got$column), "C012")
+  expect_equal(as.integer(got$rowNumber), 6L)
+  expect_equal(as.integer(got$columnNumber), 12L)
+})
+
+test_that("extractBarcodeAndPosition is vectorised", {
+  got <- extractBarcodeAndPosition(
+    c("1632405013_R006_C012", "1632405013_R007_C001")
+  )
+  expect_equal(nrow(got), 2L)
+  expect_equal(as.integer(got$rowNumber), c(6L, 7L))
+  expect_equal(as.integer(got$columnNumber), c(12L, 1L))
+})

--- a/tests/testthat/test-mldat.R
+++ b/tests/testthat/test-mldat.R
@@ -1,0 +1,154 @@
+## The bundled GoldenGate MethyLumiSet: accessors, subsetting, normalization,
+## coercion and filtering.
+
+data(mldat, package = "methylumi", envir = environment())
+
+test_that("mldat loads with the expected shape", {
+  expect_s4_class(mldat, "MethyLumiSet")
+  expect_equal(unname(dim(mldat)), c(1536L, 10L))
+  expect_equal(head(sampleNames(mldat), 3), c("M_1", "M_2", "M_3"))
+  expect_equal(head(featureNames(mldat), 3),
+               c("AATK_E63_R", "AATK_P519_R", "AATK_P709_R"))
+})
+
+test_that("assay accessors return the expected values", {
+  expect_equal(sum(betas(mldat)),        5691.890947, tolerance = TOL)
+  expect_equal(sum(pvals(mldat)),         473.826186, tolerance = TOL)
+  expect_equal(sum(methylated(mldat)),   74208765.64, tolerance = TOL)
+  expect_equal(sum(unmethylated(mldat)), 95192882.17, tolerance = TOL)
+
+  for (f in list(betas, pvals, methylated, unmethylated)) {
+    expect_equal(unname(dim(f(mldat))), c(1536L, 10L))
+    expect_false(anyNA(f(mldat)))
+  }
+})
+
+test_that("betas are bounded and pvals are probabilities", {
+  b <- betas(mldat)
+  expect_true(all(b >= 0 & b <= 1))
+  p <- pvals(mldat)
+  expect_true(all(p >= 0 & p <= 1))
+})
+
+test_that("mldat shares assayData by reference (BUG, see #35)", {
+  ## Characterization test. The shipped mldat.rda has
+  ## storageMode == "environment" rather than Biobase's default
+  ## "lockedEnvironment", so its assayData is a bare environment shared between
+  ## every copy of the object. R's copy-on-modify does not protect the payload:
+  ##
+  ##     x <- mldat
+  ##     methylated(x) <- methylated(x) + 1   # also modifies mldat
+  ##
+  ## methylumiR() and methylumIDAT() both produce "lockedEnvironment" objects,
+  ## so this is confined to the saved example dataset -- but that dataset is
+  ## what every reader of the vignette experiments with.
+  ##
+  ## Invert this when #35 is fixed.
+  expect_equal(storageMode(mldat), "environment")
+
+  x <- mldat
+  before <- sum(methylated(mldat))
+  methylated(x) <- methylated(x) + 1
+  expect_false(sum(methylated(mldat)) == before)   # the original was mutated
+
+  methylated(x) <- methylated(x) - 1               # undo, for later tests
+  expect_equal(sum(methylated(mldat)), before)
+})
+
+test_that("replacement methods round-trip", {
+  ## Work on a properly isolated copy so this test cannot leak into the others,
+  ## which is precisely what #35 causes.
+  x <- mldat
+  storageMode(x) <- "lockedEnvironment"
+
+  b <- betas(x)
+  betas(x) <- b * 0 + 0.5
+  expect_true(all(betas(x) == 0.5))
+  betas(x) <- b
+  expect_equal(betas(x), b)
+
+  m <- methylated(x)
+  methylated(x) <- m + 1
+  expect_equal(methylated(x), m + 1)
+  expect_equal(sum(methylated(mldat)), sum(m))     # original untouched
+})
+
+test_that("QC data is present and has the documented control types", {
+  qc <- QCdata(mldat)
+  expect_s4_class(qc, "MethyLumiQC")
+  expect_equal(unname(dim(qc)), c(44L, 10L))
+  expect_equal(controlTypes(mldat),
+               c("ALLELE SPECIFIC EXTENSION", "EXTENSION GAP",
+                 "FIRST HYBRIDIZATION", "GENDER", "NEGATIVE",
+                 "PCR CONTAMINATION", "SECOND HYBRIDIZATION"))
+})
+
+test_that("subsetting selects the right features and samples", {
+  s <- mldat[1:100, 1:3]
+  expect_equal(unname(dim(s)), c(100L, 3L))
+  expect_equal(sum(betas(s)), 117.900646, tolerance = TOL)
+  expect_equal(betas(s), betas(mldat)[1:100, 1:3])
+  expect_equal(sampleNames(s), head(sampleNames(mldat), 3))
+
+  expect_equal(unname(dim(mldat[, 1:3])), c(1536L, 3L))
+  expect_equal(unname(dim(mldat[1:100, ])), c(100L, 10L))
+})
+
+test_that("subsetting drops QC data (BUG, see #21)", {
+  ## Characterization test: this documents current behaviour, it does not
+  ## endorse it. eSet's "[" method drops the QC slot in callNextMethod(), and
+  ## the guard added for #21 then runs
+  ##
+  ##     x@QC <- x@QC[, j, drop = FALSE]
+  ##
+  ## against an already-NULL slot. NULL[, j, drop = FALSE] silently returns
+  ## NULL rather than erroring, so the fix is a no-op and QC data is lost on
+  ## every form of subsetting.
+  ##
+  ## When #21 is actually fixed, these expectations must be inverted to assert
+  ## that QC data survives, subset to the selected samples.
+  expect_null(QCdata(mldat[1:100, 1:3]))
+  expect_null(QCdata(mldat[, 1:3]))
+  expect_null(QCdata(mldat[1:100, ]))
+})
+
+test_that("subsetting records history", {
+  h <- getHistory(mldat[1:100, 1:3])
+  expect_true(any(grepl("Subset of 100 features & 3 samples", h$command)))
+})
+
+test_that("normalizeMethyLumiSet is unchanged", {
+  n <- normalizeMethyLumiSet(mldat)
+  expect_s4_class(n, "MethyLumiSet")
+  expect_equal(unname(dim(n)), c(1536L, 10L))
+  expect_equal(sum(betas(n), na.rm = TRUE), 5517.872753, tolerance = TOL)
+})
+
+test_that("MethyLumiSet coerces to MethyLumiM", {
+  mm <- as(mldat, "MethyLumiM")
+  expect_s4_class(mm, "MethyLumiM")
+  expect_equal(unname(dim(mm)), c(1536L, 10L))
+  expect_equal(sum(exprs(mm), na.rm = TRUE), -14514.904905, tolerance = TOL)
+})
+
+test_that("the MethyLumiM round-trip is lossy, by design", {
+  ## Betas -> M-values -> betas does not return the original values, because
+  ## estimateM applies an offset. Pinned so the size of the discrepancy cannot
+  ## drift unnoticed.
+  back <- as(as(mldat, "MethyLumiM"), "MethyLumiSet")
+  expect_equal(sum(betas(back), na.rm = TRUE), 5761.247359, tolerance = TOL)
+})
+
+test_that("varFilter keeps half the features", {
+  vf <- varFilter(mldat)
+  expect_equal(unname(nrow(vf$eset)), 768L)
+  expect_true(all(featureNames(vf$eset) %in% featureNames(mldat)))
+})
+
+test_that("combine of disjoint sample sets restores the whole", {
+  a <- mldat[, 1:5]
+  b <- mldat[, 6:10]
+  ab <- combine(a, b)
+  expect_equal(unname(dim(ab)), unname(dim(mldat)))
+  expect_equal(betas(ab)[, sampleNames(mldat)], betas(mldat))
+})

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -1,0 +1,55 @@
+## Plot functions: smoke tests only. These exist because a defunct lattice call
+## sat in parplot() undetected for years and eventually broke installation of
+## the whole package (#28). Rendering is not compared -- the point is that every
+## plotting entry point is executed by something.
+
+## Draw to a null device for the whole file. setup()/teardown() are deprecated
+## in testthat's 3rd edition, and every test here needs the same device, so open
+## it once at file scope.
+pdf(NULL)
+
+test_that("parplot works (regression test for #28)", {
+  ## parplot() called lattice::parallel, which went deprecated -> defunct ->
+  ## unexported. Because the import resolved at lazy-load time, this took the
+  ## whole package down, not just this function.
+  data(mldat, package = "methylumi", envir = environment())
+  p <- methylumi:::parplot(mldat)
+  expect_s3_class(p, "trellis")
+  expect_silent(print(p))
+})
+
+test_that("parplot accepts the documented quantiles and what arguments", {
+  data(mldat, package = "methylumi", envir = environment())
+  expect_s3_class(methylumi:::parplot(mldat, quantiles = seq(0, 1, 0.5)), "trellis")
+  expect_s3_class(methylumi:::parplot(mldat, what = "pvals"), "trellis")
+})
+
+test_that("qcplot runs on a MethyLumiSet and on its QC data", {
+  data(mldat, package = "methylumi", envir = environment())
+  expect_no_error(qcplot(mldat, "NEGATIVE"))
+  expect_no_error(qcplot(QCdata(mldat), "NEGATIVE"))
+})
+
+test_that("corplot and plotSampleIntensities run", {
+  data(mldat, package = "methylumi", envir = environment())
+  expect_no_error(corplot(mldat))
+  expect_no_error(plotSampleIntensities(mldat))
+})
+
+test_that("qc.probe.plot runs on IDAT-derived data", {
+  expect_no_error(print(qc.probe.plot(example_idats())))
+})
+
+test_that("plotNegOob is broken by modern ggplot2 (BUG, see #36)", {
+  ## Characterization test. R/plotNegOob.R:48 calls
+  ##
+  ##     scale_y_continuous(breaks = NA)
+  ##
+  ## ggplot2 used to tolerate NA there as "draw no breaks"; it now rejects it
+  ## and asks for NULL. The function is exported, so this is a user-visible
+  ## breakage, not an internal wart. One-word fix, deliberately not made here --
+  ## #27 pins current behaviour and the fix lands separately.
+  ##
+  ## Invert this when #36 is fixed.
+  expect_error(plotNegOob(example_idats()), "breaks")
+})


### PR DESCRIPTION
## What

The package had **no `tests/` directory at all**. This adds 36 tests / 105 expectations across four files, pinning current behaviour so the modernization work in #34 and #30 has something to turn red.

| File | Covers |
|---|---|
| `test-mldat.R` | accessors, replacement methods, subsetting, history, `normalizeMethyLumiSet`, `MethyLumiM` coercion, `varFilter`, `combine` |
| `test-methylumiR.R` | text import, agreement with the shipped `mldat`, `extractBarcodeAndPosition` |
| `test-methylumIDAT.R` | IDAT import, QC/OOB, noob `bgcorr`, `stripOOB`, minfi `MethylSet` coercion, **parallel == serial** |
| `test-plots.R` | smoke tests for every plotting entry point, including `parplot` as a regression test for #28 |

Values are pinned as sums and dimensions with relative tolerance rather than identity, so a BLAS or platform change doesn't turn the suite red for the wrong reason. The `parallel == serial` test is the specific guard for replacing the `.mclapply` shim in #30.

`methylumIDAT()` on the bundled IDATs takes a few seconds, so it's imported once in a helper and reused.

## Three real bugs found

Writing the suite surfaced three genuine bugs. **All three are pinned as characterization tests** — asserting the current, broken behaviour with a comment saying to invert the assertion when fixed — so this PR changes no behaviour. Fixes land separately.

**[#21](https://github.com/seandavi/methylumi/issues/21) (reopened) — QC data silently dropped by all subsetting.** The 2017 fix is a no-op and always was:

```r
dim(QCdata(mldat))          #> 44 10
QCdata(mldat[1:100, 1:3])   #> NULL
QCdata(mldat[, 1:3])        #> NULL
QCdata(mldat[1:100, ])      #> NULL
```

`callNextMethod()` dispatches to eSet's `[`, which drops the `QC` slot. The guard then runs `x@QC <- x@QC[, j, drop=FALSE]` on an already-NULL slot — and `NULL[, j, drop=FALSE]` returns NULL *silently* rather than erroring. The `slotNames()` check passes because the slot exists, it's just empty.

**[#35](https://github.com/seandavi/methylumi/issues/35) — `mldat.rda` shares assayData by reference.** `storageMode` is `"environment"`, not `"lockedEnvironment"`, so copy-on-modify doesn't protect the payload:

```r
x <- mldat
methylated(x) <- methylated(x) + 1   # also mutates mldat
```

This one broke the suite while I was writing it — a test modifying a copy changed values seen by later tests in the same file. Confined to the saved dataset; `methylumiR()` and `methylumIDAT()` both produce correct `lockedEnvironment` objects.

**[#36](https://github.com/seandavi/methylumi/issues/36) — `plotNegOob()` errors on all input.** `scale_y_continuous(breaks = NA)` at `R/plotNegOob.R:48`; ggplot2 now requires `NULL`. One-word fix.

## Notes

- `testthat (>= 3.0.0)` added to `Suggests`, `Config/testthat/edition: 3`.
- One deprecation warning remains: `qc.probe.plot()` uses `qplot()`, deprecated in ggplot2 3.4.0. Not broken yet, noted on #36.
- Local `R CMD check` shows no new errors or warnings beyond the pre-existing legacy NOTEs recorded on #27.

Part of #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)