### PR TITLE
Publish a pkgdown site to GitHub Pages (closes #43)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,6 @@
+^_pkgdown\.yml$
+^docs$
+^pkgdown$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.github$

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,0 +1,79 @@
+name: pkgdown
+
+# Push to devel and manual runs only -- deliberately NOT on pull_request. A site
+# build re-runs every example and every vignette, and methylumi450k.qmd pulls
+# TCGAMethylation450k plus the hg19 annotation packages. That is far too much
+# work to spend on every PR; R-CMD-check-bioc already covers PRs.
+on:
+  push:
+    branches: [devel]
+  workflow_dispatch:
+
+concurrency:
+  group: pkgdown
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Same container as check-bioc.yml: it has the Bioconductor dependency tree
+    # and, importantly, the system freetype/libpng/libtiff/libjpeg/libwebp
+    # headers that pkgdown's ragg dependency needs to compile.
+    container: bioconductor/bioconductor_docker:devel
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # quarto-actions/setup shells out to jq, which the Bioconductor container
+      # does not ship. Same workaround as check-bioc.yml.
+      - name: Install jq
+        run: apt-get update -qq && apt-get install -y --no-install-recommends jq
+
+      # The vignettes are .qmd, so pkgdown renders the articles with the Quarto
+      # CLI (pkgdown >= 2.1) rather than knitr.
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      # Shares the key with check-bioc.yml so the two jobs warm the same cache.
+      - name: Cache R library
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/lib/R/site-library
+          key: ${{ runner.os }}-bioc-devel-${{ hashFiles('DESCRIPTION') }}
+          restore-keys: ${{ runner.os }}-bioc-devel-
+
+      - name: Install dependencies
+        shell: Rscript {0}
+        run: |
+          options(warn = 1, Ncpus = 2)
+          BiocManager::install(ask = FALSE, update = TRUE)
+          if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")
+          remotes::install_deps(
+            dependencies = TRUE,
+            repos = BiocManager::repositories()
+          )
+          remotes::install_cran(c("pkgdown", "quarto"))
+
+      - name: Build site
+        shell: Rscript {0}
+        run: |
+          pkgdown::check_pkgdown()
+          pkgdown::build_site(install = TRUE, new_process = FALSE)
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,8 @@ Collate: AllGenerics.R
   utilities.R
   varFilter.R
 VignetteBuilder: quarto
-BugReports: https://github.com/seandavi/methylumi/issues/new
+URL: https://seandavi.github.io/methylumi/, https://github.com/seandavi/methylumi
+BugReports: https://github.com/seandavi/methylumi/issues
 License: GPL-2
 Encoding: UTF-8
 Config/testthat/edition: 3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# methylumi
+
+Reference documentation and vignettes:
+<https://seandavi.github.io/methylumi/>
+
 This package provides classes for holding and manipulating
 Illumina methylation data.  Based on eSet, it can contain MIAME
 information, sample information, feature information, and

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,71 @@
+url: https://seandavi.github.io/methylumi/
+
+template:
+  bootstrap: 5
+
+# pkgdown fails the build if any man/ topic is missing from this index, so every
+# entry below is one .Rd file. The S4 hub pages (methylumiGenerics.Rd, 55
+# aliases; the *-class pages) are single topics no matter how many generics
+# they document -- they can only be listed once, in the group that fits best.
+reference:
+- title: Package overview
+  contents:
+  - methylumi-package
+
+- title: Import
+  desc: >
+    Reading Illumina data into a MethyLumiSet: final report text files, raw
+    IDATs, and the lower-level IDAT readers.
+  contents:
+  - methylumiR
+  - methylumIDAT
+  - IDATsToMatrices
+  - IDATtoMatrix
+  - extractBarcodeAndPosition
+
+- title: Classes
+  desc: The eSet-derived containers for methylation data and its controls.
+  contents:
+  - MethyLumi-class
+  - methylData-class
+  - MethyLumiSet-class
+  - MethyLumiM-class
+  - MethyLumiQC-class
+
+- title: Accessors and generics
+  desc: >
+    Assay-data accessors (betas, methylated, unmethylated, pvals, QCdata) and
+    the generics the classes above implement, including the coercions between
+    MethyLumiSet, MethyLumiM and the minfi classes.
+  contents:
+  - betas
+  - methylumiGenerics
+  - getAssayDataNameSubstitutions
+
+- title: Preprocessing and normalization
+  desc: >
+    Background correction, dye-bias and control normalization, M-value
+    estimation, and the strippers that drop out-of-band and bead-level assays.
+  contents:
+  - normalizeMethyLumiSet
+  - estimateM
+  - MethyLumi-strippers
+
+- title: Filtering
+  contents:
+  - featureFilter
+  - varFilter
+
+- title: QC and plotting
+  contents:
+  - qcplot
+  - plotSampleIntensities
+
+- title: Pipelines
+  contents:
+  - tcgaPipeline
+
+- title: Example data
+  contents:
+  - mldat
+  - CpGs


### PR DESCRIPTION
Closes #43.

## What is here

- **`_pkgdown.yml`** with a grouped `reference:` index: package overview,
  import, classes, accessors and generics, preprocessing and normalization,
  filtering, QC and plotting, pipelines, example data. Site URL is
  `https://seandavi.github.io/methylumi/`.
- **`.github/workflows/pkgdown.yml`** — `push` to `devel` and
  `workflow_dispatch` only, *not* `pull_request`. Same
  `bioconductor/bioconductor_docker:devel` container, same jq + Quarto setup,
  and the same R library cache key as `check-bioc.yml` so the two jobs warm
  each other's cache. Deploys via `configure-pages` /
  `upload-pages-artifact` / `deploy-pages` (Pages-from-Actions, no `gh-pages`
  branch).
- **`DESCRIPTION`**: added `URL:` (site + repo) and fixed `BugReports:` to the
  issue list rather than `/issues/new`. `Version:` untouched.
- **`README.md`**: H1 plus a link to the site (pkgdown uses the README as the
  home page).
- **`.Rbuildignore`**: `^_pkgdown\.yml$`, `^docs$`, `^pkgdown$`. The new
  workflow is already covered by the existing `^\.github$`.

## The reference index — how it was validated

`pkgdown` **would not install locally**, exactly as the issue predicted:
`ragg` fails with `fatal error: ft2build.h: No such file or directory`
(no system freetype/libpng/libtiff/libjpeg/libwebp headers on the dev box).
So `check_pkgdown()` could not be run here.

Instead the index was checked with a throwaway script (not committed) that
does what `pkgdown:::select_topics` does: `tools::parse_Rd()` every
`man/*.Rd`, collect each topic's `\name` plus every `\alias`, drop
`\keyword{internal}` topics, then resolve every entry in `_pkgdown.yml`
against that set. Result:

```
internal topics (pkgdown skips these): character(0)
topics: 24  covered: 24  aliases total: 217
OK
```

No entry fails to resolve, no topic is missing, no topic is listed twice.
The workflow additionally runs `pkgdown::check_pkgdown()` before
`build_site()`, so the real check runs in CI where pkgdown installs.

The 214-aliases warning in the issue turned out to be less painful than
feared: it is only **24 Rd files**. The constraint that shaped the grouping is
that a topic is indivisible — `methylumiGenerics.Rd` carries 55 aliases
(`methylumiCSV`, `methylumi.bgcorr`, `plotNegOob`, `qc.probe.plot`, the
`intensities.*` family, …) and can only appear in one group, so the issue's
suggested split of `methylumiCSV` into "import" is not expressible. It sits
under "Accessors and generics" with the rest of its file. Likewise there is no
separate coercions topic — the `as()` methods are documented inside the
`*-class` pages — so there is no "coercions" group; it is called out in the
accessors group description instead.

## Vignettes / Quarto

Both vignettes are `.qmd` with `%\VignetteEngine{quarto::html}`. pkgdown >= 2.1
renders `.qmd` articles through the Quarto CLI, which is why the workflow keeps
the `quarto-actions/setup` step (and its jq workaround) from `check-bioc.yml`
and installs the `quarto` R package. Nothing else is needed — no `articles:`
section, the vignettes are picked up automatically. This is the one thing that
could not be verified locally; if the Quarto handoff misbehaves it will show up
on the first `devel` push, and `workflow_dispatch` is there to re-run it.

## `pkgdown` is deliberately NOT in `Suggests`

Nothing in the package, its tests, or its vignettes uses pkgdown — it is a
build tool for one CI job, which installs it explicitly. Putting it in
`Suggests` would drag it (and `ragg`, and its system libraries) into every
`remotes::install_deps(dependencies = TRUE)` in `check-bioc.yml` too, for no
benefit.

## Maintainer action required — enable Pages

The workflow cannot turn Pages on for itself; the first run will fail at
`configure-pages` until this is done. Repo settings were not touched, per the
task. Steps:

1. GitHub → **Settings** → **Pages**
2. Under **Build and deployment** → **Source**, choose **GitHub Actions**
   (not "Deploy from a branch")
3. Save. Nothing to pick for branch or folder.
4. Then either push this merge to `devel`, or go to **Actions** → **pkgdown**
   → **Run workflow** to trigger it manually.

If an environment protection prompt appears for `github-pages`, allow the
`devel` branch to deploy to it.

The site lands at https://seandavi.github.io/methylumi/, which is what
`DESCRIPTION`, `README.md` and `_pkgdown.yml` already point at.

Note that this is GitHub Pages, separate from and additional to the
Bioconductor landing page — nothing should be documented only here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
