### PR TITLE
Remove the dead gamma-family background corrections (closes #18)

### DIFF
--- a/R/bgcorr.R
+++ b/R/bgcorr.R
@@ -7,7 +7,15 @@ methylumi.bgcorr<-function(x, method='noob', offset=15, controls=NULL, correct=T
 
   allelic = FALSE
 
-  # GoldenGate: not supported (it could be, perhaps, but why?) 
+  if(tolower(method) %in% c('goob','gamma','mode')) { # {{{
+    stop("method='", method, "' was removed in methylumi 2.59.x. The gamma-family ",
+         "background corrections ('goob', 'gamma', 'mode') relied on gamma.mle(), ",
+         "gamma.mode() and gamma.integral() from the rGammaGamma package, which is ",
+         "not available from CRAN or Bioconductor, so they have not worked for ",
+         "years. Use method='noob' instead.")
+  } # }}}
+
+  # GoldenGate: not supported (it could be, perhaps, but why?)
   stopifnot(grepl('IlluminaHumanMethylation', annotation(x)))
 
   if(any(methylated(x)<=0)) { # {{{
@@ -17,11 +25,10 @@ methylumi.bgcorr<-function(x, method='noob', offset=15, controls=NULL, correct=T
     unmethylated(x)[which(unmethylated(x)==0)] <- 1
   } # }}}
 
-  # 'noob' and 'goob' are just shorthand for 'normexp, OOB', and 'gamma, OOB'
-  if(tolower(method) %in% c('noob','goob','mode')) controls = intensities.OOB(x)
+  # 'noob' is just shorthand for 'normexp, OOB'
+  if(tolower(method) == 'noob') controls = intensities.OOB(x)
   if(tolower(method) == 'lumi') controls = intensities.M(x)
   if(tolower(method) == 'noob') method = 'normexp'
-  if(tolower(method) == 'goob') method = 'gamma'
 
   # controls must be a list(Cy3=matrix, Cy5=matrix) if supplied
   if(!is.null(controls) &&  # {{{
@@ -181,9 +188,6 @@ get.xs <- function(xf, controls, method, offset=50, robust=TRUE, correct=TRUE, p
   if(method == 'normexp') return(normexp.get.xs(xf, controls, offset, robust))
   if(method == 'median') return(median.get.xs(xf, controls, offset))
   if(method == 'illumina') return(illumina.get.xs(xf, controls, offset))
-  if(method == 'gamma') return(gammaGetXs(xf, controls, offset, correct, 
-                                            parallel=parallel))
-  if(method == 'mode') return(gammaM.get.xs(xf, controls, offset, correct))
   if(method == 'lumi') return(lumi.get.xs(xf, controls, offset))
   else stop(paste('Method',method,'has not been added to get.xs() yet'))
 }  # }}}
@@ -226,50 +230,6 @@ illumina.get.xs <- function(xf, controls, offset=50, robust=TRUE, ...){#{{{
               params=data.frame(bg=bg, offset=offset),
               meta=c('background fifth percentile','offset')))
 } # }}}
-gammaGetXs <- function(xf,controls,offset=50,correct=TRUE,parallel=FALSE,...){#{{{
-
-  #require(rGammaGamma)
-  bg = sapply(seq_len(ncol(xf)), function(i) gamma.mle(controls[,i]))
-  if(correct) { # {{{
-    bgmu = colMeans(controls, na.rm=TRUE)
-    fg = sapply(seq_len(ncol(xf)), function(i) gamma.mle(pmax(xf[,i]-bgmu[i], 1))) #}}}
-  } else { # {{{
-    fg = sapply(seq_len(ncol(xf)), function(i) gamma.mle(xf[,i]))
-  } # }}}
-  params = cbind(t(fg), t(bg))
-  colnames(params) = c('gamma','alpha','delta','beta')
-  meta = c('signal shape','signal scale','background shape','background scale')
-  names(meta) = c('gamma','alpha','delta','beta')
-
-  if( parallel == TRUE ) {
-    xs = data.matrix(as.data.frame(.mclapply(seq_len(ncol(xf)), function(i) {
-           gamma.integral(xf[,i], params[i,], offset=offset)
-    })))
-  } else { 
-    cat('Estimating xs serially (probably not what you want)...', "\n")
-    xs = data.matrix(as.data.frame(lapply(seq_len(ncol(xf)), function(i) {
-           gamma.integral(xf[,i], params[i,], offset=offset)
-    })))
-  }
-  params = cbind(params, c(rep(offset, nrow(params))))
-  colnames(params) = c('gamma','alpha','delta','beta','offset')
-  meta['offset'] = 'offset'
-  return(list(xs=xs, params=as.data.frame(params), meta=meta))
-  
-} # }}}
-gammaM.get.xs <- function(xf,controls,offset=15,correct=TRUE,parallel=FALSE,...){#{{{
-
-  #require(rGammaGamma)
-  bg = sapply(seq_len(ncol(xf)), function(i) gamma.mode(gamma.mle(controls[,i])))
-  xs = sapply(seq_len(ncol(xf)), function(s) pmax(xf[,s] - bg[s], offset))
-  params = data.frame(mode=bg)
-  params$offset = offset
-  meta = c('background mode','offset')
-  names(meta) = c('mode','offset')
-  cat("Background mode estimated from", nrow(controls), "probes\n")
-  return(list(xs=xs, params=params, meta=meta))
-  
-} # }}}
 lumi.get.xs <- function(xf, controls, offset=50, robust=TRUE, nbin=1000,...){#{{{
 
   # from lumi's estimateBG() function
@@ -294,8 +254,6 @@ get.xcs <- function(xcf, method, params, robust=TRUE, correct=TRUE) { # {{{
   if(method == 'normexp') return(normexp.get.xcs(xcf, params))
   if(method == 'median') return(median.get.xcs(xcf, params))
   if(method == 'illumina') return(illumina.get.xcs(xcf, params,correct=correct))
-  if(method == 'gamma') return(gammaGetXcs(xcf, params))
-  if(method == 'mode') return(gammaM.get.xcs(xcf, params))
   if(method == 'lumi') return(lumi.get.xcs(xcf, params))
   else stop(paste('Method',method,'has not been added to get.xcs() yet'))
 }  # }}}
@@ -335,24 +293,6 @@ illumina.get.xcs <- function(xcf, params, robust=TRUE, ...){#{{{
   return(xcf+offset)
 
 } # }}}
-gammaGetXcs <- function(xcf, params, robust=TRUE, parallel=FALSE,...){#{{{
-
-  #require(rGammaGamma)
-  offset = params[[grep('offset', names(params), value=TRUE)]][1]
-  params[[grep('offset', names(params), value=TRUE)]] = NULL
-  
-  xcs = xcf
-  for(i in seq_len(ncol(xcf))) {
-    xcs[,i]=gamma.integral(xcf[,i],params=as.numeric(params[i,]),offset=offset)
-  }
-  # notice that the offset was added during the calculation of xcs|params.
-  return(xcs)
-  
-} # }}}
-gammaM.get.xcs <- function(xcf, params, robust=TRUE, parallel=FALSE, ...){ #{{{
-  bgmode = params[[grep('mode', names(params), value=TRUE)]]
-  sapply(seq_len(ncol(xcf)), function(i) pmax((xcf[,i] - bgmode[i]), offset))
-} # }}}
 lumi.get.xcs <- function(xcf, params, robust=TRUE, ...){#{{{
 
   stopifnot(any(grepl('mode', names(params))))
@@ -384,11 +324,4 @@ normexp.signal <- function (par, x)  { # {{{
     signal[o] <- pmax(signal[o], 1e-06)
   }
   signal
-} # }}}
-
-# gamma deconvolution (conditional expectation of xs|xf; my code)
-gammaSignal <- function (par, x)  { # {{{
-  #require(rGammaGamma)
-  par = as.numeric(par)
-  gamma.integral(x, par, offset=0)
 } # }}}

--- a/tests/testthat/test-methylumIDAT.R
+++ b/tests/testthat/test-methylumIDAT.R
@@ -52,6 +52,16 @@ test_that("noob background correction is unchanged", {
   expect_equal(sum(is.na(betas(bg))), 3L)
 })
 
+test_that("the removed gamma-family methods give an informative error", {
+  ## #18: these called gamma.mle()/gamma.mode()/gamma.integral() from the
+  ## unavailable rGammaGamma package. They must not fail with "could not find
+  ## function" any more.
+  for (m in c("goob", "gamma", "mode", "GOOB")) {
+    expect_error(methylumi.bgcorr(example_idats(), method = m),
+                 "rGammaGamma")
+  }
+})
+
 test_that("stripOOB drops the out-of-band assays without touching betas", {
   mi <- example_idats()
   so <- stripOOB(mi)


### PR DESCRIPTION
Closes #18

`methylumi.bgcorr(method = "goob")` failed with `could not find function "gamma.mle"`.

## Root cause

`gamma.mle()`, `gamma.mode()` and `gamma.integral()` are called in `R/bgcorr.R`
but defined nowhere in the package. They come from `rGammaGamma`
(ttriche/rGammaGamma), a GitHub-only package that is not in CRAN or Bioconductor
and never was. `R/bgcorr.R` carried four commented-out `#require(rGammaGamma)`
lines. Every gamma-family background correction has therefore been dead for
years.

## What changed

Per the maintainer's decision (option 1), the gamma-family methods are removed.

Method strings confirmed dead by grep and now rejected:

| method | routed to | missing function |
| --- | --- | --- |
| `goob` | remapped to `gamma` -> `gammaGetXs()` | `gamma.mle`, `gamma.integral` |
| `gamma` | `gammaGetXs()` / `gammaGetXcs()` | `gamma.mle`, `gamma.integral` |
| `mode` | `gammaM.get.xs()` | `gamma.mode`, `gamma.mle` |

Unaffected and still working: `noob` (the default, remapped to `normexp`),
`normexp`, `median`, `illumina`, `lumi`. There is no `oob` method or any other
gamma variant — `goob` was the only shorthand besides `noob`.

Deleted: `gammaGetXs()`, `gammaM.get.xs()`, `gammaGetXcs()`, `gammaM.get.xcs()`,
the unused `gammaSignal()` helper, the `gamma`/`mode` branches in `get.xs()` and
`get.xcs()`, the `goob` -> `gamma` remap, and the dead
`#require(rGammaGamma)` comments. `get.xs()`/`get.xcs()` themselves stay — they
still dispatch the four surviving methods.

Added an early guard in `methylumi.bgcorr()` so a removed method gets an
actionable error naming the removal and pointing at `method = "noob"`, instead
of a cryptic `could not find function` from deep inside an `lapply()`.

## Callers and docs

Checked every caller. All of them use the `noob` default and needed no change:
`tcgaPipeline()` (`R/utilities.R`), `methylumIDAT(normalize=TRUE)` ->
`normalizeMethyLumiSet()` (which has no `method=` argument of its own and never
forwards one), and `vignettes/methylumi450k.qmd`. No `.Rd` file, roxygen block
or vignette documented or defaulted to a removed method —
`methylumi.bgcorr` appears in `man/methylumiGenerics.Rd` as an alias only, with
no method list, so no documentation edit was required.

## Tests

`tests/testthat/test-methylumIDAT.R`: the existing golden-value test
"noob background correction is unchanged" still passes unmodified, so `noob`
output is byte-for-byte what it was. Added a test asserting `goob`, `gamma`,
`mode` and `GOOB` all error with a message mentioning `rGammaGamma`.

`[ FAIL 0 | WARN 1 | SKIP 0 | PASS 122 ]` — the one warning is the pre-existing
`qplot()` deprecation tracked in #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
