### PR TITLE
Read IDATs from per-slide subdirectories (closes #19)

### DIFF
--- a/R/methylumIDAT.R
+++ b/R/methylumIDAT.R
@@ -98,6 +98,25 @@ getMethylationBeadMappers <- function(chipType=c('450k','27k'), genome=c('hg19',
 
 } # }}}
 
+## Illumina writes IDATs either flat in one directory or, more commonly, one
+## directory per slide (<idatPath>/<Slide>/<Slide>_<Array>_Grn.idat). Resolve a
+## bare IDAT filename against either layout, returning NA if it is not there.
+## ponytail: rescans idatPath once per file that is not flat; if that ever costs
+## anything for thousands of samples, hoist the recursive listing into a single
+## call in methylumIDAT()/IDATsToMatrices() and pass the index down.
+.findIDAT <- function(idatPath, filename) { # {{{
+  flat <- file.path(idatPath, filename)
+  if (file.exists(flat)) return(flat)
+  hits <- list.files(idatPath, pattern=glob2rx(filename), recursive=TRUE,
+                     full.names=TRUE)
+  if (length(hits) == 0) return(NA_character_)
+  if (length(hits) > 1) {
+    stop("'", filename, "' is ambiguous: found in more than one subdirectory ",
+         "of '", idatPath, "': ", paste(hits, collapse=", "))
+  }
+  hits
+} # }}}
+
 #' process a single IDAT (just the mean intensities)
 #' 
 #' @param x character(1)
@@ -109,7 +128,11 @@ IDATtoMatrix <- function(x,fileExts=list(Cy3="Grn",Cy5="Red"),idatPath='.'){#{{{
   names(chs) = fileExts
   processed = lapply(fileExts, function(ch) {
     ext = paste(ch, 'idat', sep='.')
-    dat = readIDAT(file.path(idatPath, paste(x, ext, sep='_')))
+    idatFile = .findIDAT(idatPath, paste(x, ext, sep='_'))
+    if (is.na(idatFile)) {
+      stop("Cannot find ", paste(x, ext, sep='_'), " under '", idatPath, "'")
+    }
+    dat = readIDAT(idatFile)
     Quants = data.matrix(dat$Quants)
     colnames(Quants) = paste(chs[ch], colnames(Quants), sep='.')
     return(list(Quants=Quants, 
@@ -492,7 +515,7 @@ methylumIDAT <- function(barcodes=NULL,pdat=NULL,parallel=FALSE,n=FALSE,n.sd=FAL
   } # }}}
   files.present = rep(TRUE, length(barcodes)) # {{{
   idats = sapply(barcodes, function(b) paste(b,c('_Red','_Grn'),'.idat',sep=''))
-  for(i in colnames(idats)) for(j in idats[,i]) if(!j %in% list.files(idatPath))  {
+  for(i in colnames(idats)) for(j in idats[,i]) if(is.na(.findIDAT(idatPath,j))) {
     message(paste('Error: file', j, 'is missing for sample', i))
     files.present = FALSE
   }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -46,12 +46,11 @@ t.submit <- function() as.character(Sys.time())
 t.finish <- function() as.character(format(Sys.time(), "%H:%M:%S"))
 
 ## handy for grabbing all IDAT files in an Illumina directory
+## Handles both a flat directory and Illumina's one-directory-per-slide layout.
 getBarcodes <- function(path=".") { # {{{
-  oldwd <- getwd()
-  setwd(path)
   barcds <- unique(gsub("_(Red|Grn).idat","",
-                        list.files(path=path,patt="idat")))
-  setwd(oldwd)
+                        basename(list.files(path=path,patt="idat",
+                                            recursive=TRUE))))
   names(barcds) <- barcds
   return(barcds)
 } # }}}

--- a/tests/testthat/test-methylumIDAT.R
+++ b/tests/testthat/test-methylumIDAT.R
@@ -67,6 +67,46 @@ test_that("MethyLumiSet coerces to a minfi MethylSet", {
   expect_equal(sum(minfi::getBeta(ms), na.rm = TRUE), 25692.398717, tolerance = TOL)
 })
 
+## Copy the bundled IDATs into <dir>/<Slide>/ subdirectories, the layout the
+## scanner actually writes (see #19).
+nested_idat_path <- function() {
+  dir <- tempfile("nested-idats-")
+  dir.create(dir)
+  for (f in list.files(idat_path(), pattern = "\\.idat$", full.names = TRUE)) {
+    slide <- sub("_.*$", "", basename(f))
+    dir.create(file.path(dir, slide), showWarnings = FALSE)
+    file.copy(f, file.path(dir, slide, basename(f)))
+  }
+  dir
+}
+
+test_that("methylumIDAT reads IDATs in per-slide subdirectories (#19)", {
+  nested <- nested_idat_path()
+  expect_equal(getBarcodes(nested), setNames(idat_barcodes(), idat_barcodes()))
+
+  mi <- example_idats()
+  ne <- suppressMessages(methylumIDAT(idat_barcodes(), idatPath = nested))
+  expect_equal(sampleNames(ne), sampleNames(mi))
+  expect_identical(betas(ne),        betas(mi))
+  expect_identical(methylated(ne),   methylated(mi))
+  expect_identical(unmethylated(ne), unmethylated(mi))
+  expect_identical(intensities.OOB(ne), intensities.OOB(mi))
+})
+
+test_that("an IDAT in two subdirectories is an error, not a coin flip (#19)", {
+  nested <- nested_idat_path()
+  dir.create(file.path(nested, "elsewhere"))
+  dupe <- "5318317007_A_Grn.idat"
+  file.copy(file.path(idat_path(), dupe), file.path(nested, "elsewhere", dupe))
+  expect_error(suppressMessages(methylumIDAT(idat_barcodes(), idatPath = nested)),
+               "ambiguous")
+})
+
+test_that("a genuinely missing IDAT is still reported", {
+  expect_error(suppressMessages(
+    methylumIDAT("9999999999_A", idatPath = idat_path())), "files.present")
+})
+
 test_that("IDATsToMatrices reads both channels", {
   mats <- suppressMessages(
     IDATsToMatrices(idat_barcodes(), idatPath = idat_path())


### PR DESCRIPTION
Closes #19.

Illumina's scanners write IDATs one directory per slide —
`<idatPath>/<Slide>/<Slide>_<Array>_Grn.idat` — but `methylumIDAT()` assumed a
flat directory in two places, so a standard scanner output directory failed
with `Error: file X is missing for sample Y`.

The reporter's suggested `list.files(idatPath, recursive = TRUE)` is not enough
on its own: `recursive = TRUE` returns paths *relative to* `idatPath`, which
never `%in%`-match the bare basenames the check compares against, and even if
the check passed, `IDATtoMatrix()` still builds a flat
`file.path(idatPath, basename)` when it actually reads the file.

## Fix

New internal `.findIDAT(idatPath, filename)` resolves one bare IDAT filename:

- `file.path(idatPath, filename)` if it exists — the flat fast path, no
  directory scan at all;
- otherwise a `recursive = TRUE` search returning the full path;
- `NA` if absent, so the caller keeps reporting the missing file per sample;
- `stop()` listing every conflicting path if the same basename lives in more
  than one subdirectory, rather than silently picking one.

Both the presence check in `methylumIDAT()` and the read in `IDATtoMatrix()`
(and so `IDATsToMatrices()`, `lumIDAT()`) now route through it.
`getBarcodes()` gets the same recursive treatment, and loses a `setwd()`
round-trip it did not need.

## Tests

`tests/testthat/test-methylumIDAT.R` copies the three bundled 27k IDATs into a
temporary `<tmp>/5318317007/` layout and asserts `methylumIDAT()` reads it to
assay data **identical** to the flat read (betas, methylated, unmethylated,
OOB), plus that `getBarcodes()` finds them. Two more tests cover the ambiguous
duplicate-basename error and the still-reported genuinely-missing file.

Flat-layout reading is unchanged: it short-circuits on `file.exists()` before
any listing happens, and the existing golden-value tests captured from 2.59.1
still pass untouched. `[ FAIL 0 | WARN 1 | SKIP 0 | PASS 126 ]` — the lone
warning is the pre-existing `ggplot2::qplot()` deprecation (#40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
