### PR TITLE
Make diagnostics() work on objects without a color channel

### DIFF
--- a/R/qc.probe.plot.R
+++ b/R/qc.probe.plot.R
@@ -131,34 +131,46 @@ methylumi.diagnostics <- function (x, onlybg=FALSE) { # {{{
                  green = log2(negctls(x.qc, "Cy3")))
       message("(Using negative controls for dashed vertical background line)")
   } # }}}
+  ## annotation() is character(0) on objects that never had a platform set
+  ## (e.g. mldat, read from a Sentrix CSV), so compare with identical(), not ==.
   if(!('COLOR_CHANNEL' %in% fvarLabels(x))) { # {{{
-    if(annotation(x) == 'IlluminaHumanMethylation27k') { 
+    if(identical(annotation(x), 'IlluminaHumanMethylation27k')) {
       fData(x)$COLOR_CHANNEL = mget(featureNames(x),
                                     IlluminaHumanMethylation27kCOLORCHANNEL)
-    } else if(annotation(x) == 'IlluminaHumanMethylation450k') { 
+    } else if(identical(annotation(x), 'IlluminaHumanMethylation450k')) {
       fData(x)$COLOR_CHANNEL = mget(featureNames(x),
                                     IlluminaHumanMethylation450kCOLORCHANNEL)
     }
   } # }}}
   assays <- c("exprs", "methylated", "unmethylated")
   if(onlybg) assays <- c("methylated", "unmethylated")
-  is.450k = (annotation(x) == 'IlluminaHumanMethylation450k')
-  par(mfrow = c(length(assays), 2 + is.450k))
-  dye <- list('red'='Cy5','green'='Cy3')
-  if(is.450k) dye[['both']] = 'Design II'
+  is.450k = identical(annotation(x), 'IlluminaHumanMethylation450k')
+  # {{{ one panel column per probe set; the red/Grn swap below is deliberate
+  colorchannel <- fData(x)[['COLOR_CHANNEL']]
+  if(is.null(colorchannel)) {
+    # ponytail: no per-probe colour channel (GoldenGate data, unannotated 27k
+    # CSV); plot every probe in a single column rather than erroring out.
+    dye <- list(all='all')
+    probesets <- list(all=seq_len(nrow(x)))
+  } else {
+    dye <- list('red'='Cy5','green'='Cy3')
+    probesets <- list(red=which(colorchannel=='Grn'),
+                      green=which(colorchannel=='Red'))
+    if(is.450k) {
+      dye[['both']] = 'Design II'
+      probesets[['both']] = which(colorchannel=='Both')
+    }
+  } # }}}
+  par(mfrow = c(length(assays), length(dye)))
   for(assay in assays) {
     for(channel in names(dye)) {
-      if(channel=="red") { # {{{
-        probes = which(fData(x)[['COLOR_CHANNEL']]=='Grn')
-        chcolor = channel # }}}
-      } else if(channel=="green") { # {{{
-        probes = which(fData(x)[['COLOR_CHANNEL']]=='Red')
-        chcolor = channel # }}}
-      } else if(channel=="both") { # {{{
-        probes=which(fData(x)[['COLOR_CHANNEL']]=='Both')
-        chcolor = ifelse(assay == 'exprs', 'blue', 
-                         ifelse(assay == 'methylated', 'green', 'red'))
-      } # }}}
+      probes <- probesets[[channel]]
+      chcolor <- switch(channel,
+                        both = ifelse(assay == 'exprs', 'blue',
+                                      ifelse(assay == 'methylated', 'green',
+                                             'red')),
+                        all = 'blue',
+                        channel)
       if (assay == "exprs") { # {{{
         if (is(x, "MethyLumiM")) { # {{{
           dat <- mvals(x)[probes, ]
@@ -183,19 +195,22 @@ methylumi.diagnostics <- function (x, onlybg=FALSE) { # {{{
         title(paste(xlab, ":", dye[[channel]], "probes")) # }}}
       } else { # {{{ methylated/unmethylated
         dat <- log2(assayDataElement(x, assay)[probes,])
-        plot.density(density(na.omit(dat)), col = "white", xlim = c(0, 16), 
-                     ylim = c(0, 0.8), lwd = 1, xlab = "log2(Intensity)", 
-                     ylab = "Proportion", main = "", lty = 1)
-        for(i in 1:dim(dat)[2]) lines(density(dat[, i]), col=chcolor, lty=1)
+        ## stats::plot.density is a method, not an exported function: call plot()
+        plot(density(na.omit(dat)), col = "white", xlim = c(0, 16),
+             ylim = c(0, 0.8), lwd = 1, xlab = "log2(Intensity)",
+             ylab = "Proportion", main = "", lty = 1)
+        for(i in 1:dim(dat)[2]) {
+          lines(density(na.omit(dat[, i])), col=chcolor, lty=1)
+        }
         if (!is.null(x.qc)) {
-          if(channel=='both' && assay=='methylated') bgch = bg[['green']]
-          else if(channel=='both' && assay=='unmethylated') bgch = bg[['red']]
+          if(channel=='both') bgch = bg[[ifelse(assay=='methylated','green','red')]]
+          else if(channel=='all') bgch = do.call(rbind, bg)
           else bgch = bg[[channel]]
           for(bgmean in colMeans(bgch, na.rm=TRUE)) {
             abline(v=bgmean, col=paste("dark",chcolor,sep=""), lty=3, lwd=1)
           }
-          title(paste(assay, "intensities:", dye[[channel]]))
         }
+        title(paste(assay, "intensities:", dye[[channel]]))
       } # }}}
     }
   }

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -53,6 +53,15 @@ test_that("the ggplot2 plots build without deprecation warnings (#40)", {
   }
 })
 
+test_that("diagnostics runs with and without COLOR_CHANNEL (regression test for #23)", {
+  ## mldat has neither annotation() nor a COLOR_CHANNEL column; the IDAT object
+  ## has both. Both go through methylumi.diagnostics(), which also called the
+  ## non-existent plot.density().
+  data(mldat, package = "methylumi", envir = environment())
+  expect_message(diagnostics(mldat), "negative controls")
+  expect_no_error(diagnostics(example_idats()))
+})
+
 test_that("plotNegOob runs (regression test for #36)", {
   ## scale_y_continuous(breaks = NA) errored under current ggplot2, which wants
   ## NULL to mean "draw no breaks".


### PR DESCRIPTION
Closes #23.

## The error today

The issue title says `plot.density not found`, but on 2.59.2 the failure happens earlier:

```r
library(methylumi); data(mldat)
diagnostics(mldat)
#> (Using negative controls for dashed vertical background line)
#> Error: argument is of length zero
```

Traceback lands on `R/qc.probe.plot.R`:

```r
if (annotation(x) == 'IlluminaHumanMethylation27k') { ... }
```

`mldat` has no annotation, so `annotation(x)` is `character(0)`, `==` gives `logical(0)`, and `if()` refuses it. Two more comparisons in the same function had the same shape. All three now use `identical()`.

## The real root cause

Guarding the comparison only moves the failure. `methylumi.diagnostics()` splits features on `fData(x)$COLOR_CHANNEL` inside the plotting loop, and `mldat` has no such column — it is 1536-probe GoldenGate data, not an Infinium chip, so the annotation packages that would supply `COLOR_CHANNEL` do not cover it. Every panel would have been drawn from zero probes.

That is why the reporter saw it work on their data and not on the package's own example data.

Fix: build the panel list once, before the loop, instead of deciding per iteration.

- `COLOR_CHANNEL` present -> one column per channel (`red`/`green`, plus `both` on 450k), exactly as before.
- absent -> a single column over all probes.

This replaces the per-channel `if/else` chain inside the loop, so the fallback is defined in one place and all three assay rows (`exprs`, `methylated`, `unmethylated`) work either way. `par(mfrow=)` is now driven off the panel list rather than a hardcoded `2 + is.450k`.

## The historical bug is still real

`plot.density` is a method, not an exported function, so the `methylated`/`unmethylated` panels called something that does not exist. That line is on the path for every object, annotated or not, so it would have fired next. Changed to `plot()`, as the reporter suggested.

Two smaller things on the same path:

- the per-sample `density(dat[, i])` calls did not drop NAs, unlike the aggregate call two lines above;
- `title()` sat inside the `if (!is.null(x.qc))` branch, so panels went unlabeled when an object had no control data. Moved out.

## Test

`tests/testthat/test-plots.R` gains a case covering both shapes: `mldat` (no annotation, no `COLOR_CHANNEL`) and the IDAT fixture (both present). Output goes to the file-scope `pdf(NULL)` the other plot tests already use.

`testthat::test_local()`: 0 failures, 120 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)