### PR TITLE
Replace deprecated qplot() with ggplot() + explicit geoms (closes #40)

### DIFF
--- a/R/MoreGenerics.R
+++ b/R/MoreGenerics.R
@@ -68,9 +68,12 @@ setMethod("plotNAs", signature(object="methylData"), function(object){ # {{{
                       pop(strsplit(x, '_')[[1]])
                     })))
   NAs <- NAs[order(NAs$dropouts),]
-  ggplot2::qplot(data=NAs, x=index, y=dropouts, size=dropouts, colour=slot,
-                 geom=c('segment','point'), yend=0, xend=index, xlab='Sample #',
-                 main=paste('Probe dropouts, colored by position, p >', pval))
+  ## size= on a segment is deprecated in ggplot2; linewidth is the same value.
+  ggplot2::ggplot(NAs, ggplot2::aes(x=index, y=dropouts, colour=slot)) +
+    ggplot2::geom_segment(ggplot2::aes(xend=index, yend=0, linewidth=dropouts)) +
+    ggplot2::geom_point(ggplot2::aes(size=dropouts)) +
+    ggplot2::labs(x='Sample #', y='dropouts',
+                  title=paste('Probe dropouts, colored by position, p >', pval))
 }) # }}}
 setGeneric('plotProbeNAs', # {{{ 
            function(object) standardGeneric('plotProbeNAs')
@@ -79,9 +82,10 @@ setMethod("plotProbeNAs",signature(object="methylData"),function(object){ # {{{
   pval <- pval.detect(object)
   x <- data.frame(drops=probeNAs(object)/dim(object)[2], 
                   mu=rowMeans(betas(object),na.rm=TRUE))
-  ggplot2::qplot(geom='jitter', x=mu, y=drops, ylab='failed probes',xlab='mean',
-                 main=paste('Probe dropouts, colored by mean beta, p >', pval),
-                 data=x, colour=mu)
+  ggplot2::ggplot(x, ggplot2::aes(x=mu, y=drops, colour=mu)) +
+    ggplot2::geom_jitter() +
+    ggplot2::labs(x='mean', y='failed probes',
+                  title=paste('Probe dropouts, colored by mean beta, p >', pval))
 }) # }}}
 
 if(!isGeneric('controlTypes')) setGeneric('controlTypes', # {{{

--- a/R/qc.probe.plot.R
+++ b/R/qc.probe.plot.R
@@ -91,16 +91,22 @@ qc.probe.plot <- function(obj,controltype="negnorm",log2=TRUE,by.type=FALSE,...)
                      'point')
   if( tolower(controltype) == 'oob' ) {
     qc$grouping = paste(qc$variable, qc$type, sep='.')
-    p <- ggplot2::qplot(data = qc, colour = type, fill = type, group = grouping,
-                        x = variable, y = value, geom = 'boxplot', main=a.title,
-                        xlab="Sample", ylab="Intensities") + 
-                        coord_flip() 
+    p <- ggplot2::ggplot(qc, ggplot2::aes(x = variable, y = value, colour = type,
+                                          fill = type, group = grouping)) +
+                        ggplot2::geom_boxplot() +
+                        ggplot2::labs(title = a.title,
+                                      x = "Sample", y = "Intensities") +
+                        coord_flip()
     if (log2) p <- p + scale_x_continuous(trans='log2', limits=c(2**4, 2**16))
     else p <- p + scale_x_continuous(limits=c(2**4, 2**16))
   } else {
-    p <- ggplot2::qplot(data = qc, colour = type, shape = type, 
-                        x = value, y = variable, geom = geometry,
-                        main=a.title, ylab="Sample", xlab="Intensities")
+    p <- ggplot2::ggplot(qc, ggplot2::aes(x = value, y = variable,
+                                          colour = type, shape = type)) +
+                        ## geometry is 'jitter' for negnorm controls, else 'point'
+                        (if (geometry == 'jitter') ggplot2::geom_jitter()
+                         else ggplot2::geom_point()) +
+                        ggplot2::labs(title = a.title,
+                                      x = "Intensities", y = "Sample")
     p <- p + scale_y_discrete( limits=rev(sampleNames(obj)) ) # more readable
     if (log2) p <- p + scale_x_continuous(trans='log2', limits=c(2**4, 2**16))
     else p <- p + scale_x_continuous(limits=c(2**4, 2**16))

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -40,6 +40,19 @@ test_that("qc.probe.plot runs on IDAT-derived data", {
   expect_no_error(print(qc.probe.plot(example_idats())))
 })
 
+test_that("the ggplot2 plots build without deprecation warnings (#40)", {
+  ## These used qplot(), deprecated in ggplot2 3.4.0. lifecycle only warns once
+  ## per session by default, so force it on for the duration of the test.
+  old <- options(lifecycle_verbosity = "warning")
+  on.exit(options(old), add = TRUE)
+  data(mldat, package = "methylumi", envir = environment())
+  for (p in list(qc.probe.plot(example_idats()),
+                 plotNAs(mldat),
+                 plotProbeNAs(mldat))) {
+    expect_no_warning(expect_no_error(ggplot2::ggplot_build(p)))
+  }
+})
+
 test_that("plotNegOob runs (regression test for #36)", {
   ## scale_y_continuous(breaks = NA) errored under current ggplot2, which wants
   ## NULL to mean "draw no breaks".


### PR DESCRIPTION
Closes #40

`qplot()` was deprecated in ggplot2 3.4.0 and warned on every build of `qc.probe.plot()`, `plotNAs()` and `plotProbeNAs()`. All four call sites are now `ggplot()` + explicit `geom_*()` layers.

## The "vector of geoms" turned out not to be one

The issue expected `qc.probe.plot()` to pass `c('boxplot'|'jitter', 'point')`. The code actually reads:

```r
geometry <- ifelse(tolower(controltype) == 'negnorm',
                   ifelse(tolower(controltype)=='oob', 'boxplot', 'jitter'),
                   'point')
```

`controltype` is length-1, so this always collapses to a scalar — `'jitter'` for negnorm controls, `'point'` otherwise (the inner `'boxplot'` arm is unreachable; the oob branch has its own hard-coded `geom='boxplot'` call). One conditional layer covers it. Left the `geometry` expression itself alone — out of scope.

`plotNAs()` genuinely did pass `geom=c('segment','point')`, and that became two explicit layers.

## One deliberate behaviour change

`plotNAs()` mapped `size = dropouts` at plot level, which `geom_segment` picks up — and `size` on a line is itself deprecated in ggplot2 3.4.0 (it was the *second* warning in the test output). The segment layer now maps `linewidth = dropouts` and the point layer keeps `size = dropouts`. The two guides merge into one legend, so the legend layout is unchanged, but the computed widths differ: `scale_size` uses an area (sqrt) palette, `scale_linewidth` a linear one — mean relative difference 0.23 on `mldat`, 0 on the bundled IDATs (all dropouts equal there). Linear is the correct palette for a line width; this is the intended fix, not drift.

## Verification

No vdiffr, so I diffed the built plot instead. For each of nine cases — `qc.probe.plot()` on the bundled IDATs with default / `by.type=TRUE` / `log2=FALSE` / `controltype="NEGATIVE"` / `controltype="oob"`, plus `plotNAs()` and `plotProbeNAs()` on both `mldat` and the IDATs — I captured `ggplot_build(p)$data` (every layer, every column, seeded so `position_jitter` is reproducible), the layers' geom/stat/position classes, the layer and plot mappings, `p$labels`, the scale list, the facet class and the panel layout. Before on `devel`, after on this branch, compared column by column.

**Everything is byte-identical except the two intended `plotNAs()` changes above** and one cosmetic consequence of moving `xend`/`yend` from the plot mapping to the segment layer: the point layer's built data no longer carries unused `xend`/`yend` columns. `GeomPoint` ignores them, so rendering is unaffected.

Not fixed here, and not a regression: `qc.probe.plot(x, controltype="oob")` errors identically before and after (`'log' not meaningful for factors` — `coord_flip()` plus `scale_x_continuous(trans='log2')` against a discrete axis). Pre-existing, separate bug.

## Test

One new block in `tests/testthat/test-plots.R` asserting each of the three plots builds and emits no warning, with `lifecycle_verbosity = "warning"` set so the deprecation isn't silently swallowed by lifecycle's once-per-session throttle. `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 124 ]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
