### PR TITLE
Fix the pkgdown article build (quarto renders against a stale methylumi)

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -63,11 +63,23 @@ jobs:
           )
           remotes::install_cran(c("pkgdown", "quarto"))
 
+      # Install the package ourselves, into the ordinary site-library, rather
+      # than letting build_site(install = TRUE) do it. pkgdown installs into a
+      # *temporary* library, which is only on .libPaths() of the R process that
+      # created it. Quarto renders each .qmd in a fresh R session, which
+      # inherits none of that, so library(methylumi) in a vignette resolves
+      # against whatever stale methylumi the container/cache already has --
+      # which is how the article build died with the long-fixed
+      # "object 'parallel' is not exported by 'namespace:lattice'" (#28).
+      - name: Install methylumi
+        shell: Rscript {0}
+        run: install.packages(".", repos = NULL, type = "source")
+
       - name: Build site
         shell: Rscript {0}
         run: |
           pkgdown::check_pkgdown()
-          pkgdown::build_site(install = TRUE, new_process = FALSE)
+          pkgdown::build_site(install = FALSE, new_process = FALSE)
 
       - uses: actions/configure-pages@v5
 


### PR DESCRIPTION
## The failure

The `pkgdown` workflow got through all 24 reference pages and then died in the
articles stage with nothing useful in the log:

```
Running `quarto render`
Error in `quarto::quarto_render()`:
! Error running quarto CLI from R.
ℹ Rerun with `quiet = FALSE` to see the full error message.
```

`build_site()` renders articles with `quiet = TRUE` and gives no way to change
that, so a temporary `build_articles(quiet = FALSE)` run was used to surface the
real error ([run 31817832555](https://github.com/seandavi/methylumi/actions/runs/31817832555)):

```
! package or namespace load failed for 'methylumi':
 object 'parallel' is not exported by 'namespace:lattice'
Quitting from methylumi.qmd:83-93 [load]
```

## The cause

`pkgdown::build_site(install = TRUE)` installs the package into a *temporary*
library, which only exists on the `.libPaths()` of the R process that made it.
The vignettes are `.qmd`, so pkgdown renders them by shelling out to the Quarto
CLI, which starts a fresh R session per file — and that session inherits none of
the temporary library. `library(methylumi)` in the vignettes therefore resolved
against the stale methylumi already sitting in the container's site-library,
which still carries the defunct `lattice::parallel` import fixed in #28.

This is also why `R-CMD-check-bioc` is green on the same commit: `R CMD check`
installs into a check library and exports `R_LIBS`, which child processes *do*
inherit.

## The fix

Install the package into the ordinary site-library in its own step and pass
`install = FALSE`, so the child Quarto sessions see the package being
documented. No vignette or `_quarto.yml` changes needed.

**Build site** is green: [run 31818328713](https://github.com/seandavi/methylumi/actions/runs/31818328713).

The `configure-pages` step still fails with `Get Pages site failed`. That is the
repository setting, not this workflow — it needs Settings → Pages → Source →
GitHub Actions, and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)